### PR TITLE
Add support for SQLParameter.Size & procedure class property names that are different than the procedure's parameter names

### DIFF
--- a/EntityFrameworkExtras.sln
+++ b/EntityFrameworkExtras.sln
@@ -6,6 +6,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFrameworkExtras.Tests", "EntityFrameworkExtras.Tests\EntityFrameworkExtras.Tests.csproj", "{8522B7EB-3D2D-4E43-BA3D-3F16095B8EFB}"
 EndProject
 Global
+	GlobalSection(SubversionScc) = preSolution
+		Svn-Managed = True
+		Manager = AnkhSVN - Subversion Support for Visual Studio
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU

--- a/EntityFrameworkExtras/StoredProcedureParameterAttribute.cs
+++ b/EntityFrameworkExtras/StoredProcedureParameterAttribute.cs
@@ -19,9 +19,36 @@ namespace EntityFrameworkExtras
             Direction = ParameterDirection.Input;
         }
 
+        public StoredProcedureParameterAttribute(SqlDbType dataType, int size)
+        {
+            DataType = dataType;
+            Direction = ParameterDirection.Input;
+            Size = size;
+        }
+
+        public StoredProcedureParameterAttribute(SqlDbType dataType, StoredProcedureParameterOptions options, int size)
+        {
+            DataType = dataType;
+            Options = options;
+            Direction = ParameterDirection.Input;
+            Size = size;
+        }
+
         public SqlDbType DataType { get; set; }
 
         public StoredProcedureParameterOptions Options { get; set; }
+
+        /// <summary>
+        /// Specifies the Max Size for the SqlParameter, which is required for execution when this error occurs: "String[1]: the Size property has an invalid size of 0."
+        /// More Info: http://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlparameter.size(v=vs.110).aspx
+        /// For varchar(max), use -1: http://stackoverflow.com/questions/973260/what-size-do-you-use-for-varcharmax-in-your-parameter-declaration
+        /// </summary>
+        public int Size { get; set; }
+
+        /// <summary>
+        /// Specifies the name of the Procedure parameter, if different than the property name. 
+        /// </summary>
+        public string ParameterName { get; set; }
 
         public ParameterDirection Direction { get; set; }
     }

--- a/EntityFrameworkExtras/StoredProcedureParameterInfo.cs
+++ b/EntityFrameworkExtras/StoredProcedureParameterInfo.cs
@@ -10,6 +10,7 @@ namespace EntityFrameworkExtras
         internal SqlDbType SqlDataType { get; set; }
         internal bool IsMandatory { get; set; }
         internal bool IsUserDefinedTable { get; set; }
+        internal int Size { get; set; }
         internal PropertyInfo PropertyInfo { get; set; }
     }
 }

--- a/EntityFrameworkExtras/StoredProcedureParser.cs
+++ b/EntityFrameworkExtras/StoredProcedureParser.cs
@@ -65,7 +65,8 @@ namespace EntityFrameworkExtras
                             IsMandatory = isMandatory,
                             SqlDataType = attribute.DataType,
                             PropertyInfo = propertyInfo,
-                            Direction = attribute.Direction                           
+                            Direction = attribute.Direction,
+                            Size = attribute.Size
                         });
                 }
             }
@@ -96,6 +97,7 @@ namespace EntityFrameworkExtras
                 SqlParameter sqlParameter = GenerateSqlParameter(p.Name,
                                                                  value,
                                                                  p.IsMandatory,
+                                                                 p.Size,
                                                                  p.IsUserDefinedTable,
                                                                  p.IsUserDefinedTable ?
                                                                                     _helper.GetUserDefinedTableType(p.PropertyInfo) : null,
@@ -108,13 +110,14 @@ namespace EntityFrameworkExtras
             return sqlParams.ToArray();
         }
 
-        private static SqlParameter GenerateSqlParameter(string parameterName, object paramValue, bool mandatory,
+        private static SqlParameter GenerateSqlParameter(string parameterName, object paramValue, bool mandatory, int size,
                                            bool isUserDefinedTableParameter, string udtType, SqlDbType dataType, ParameterDirection direction)
         {
             var sqlParameter = new SqlParameter("@" + parameterName, paramValue ?? DBNull.Value)
             {
                 Direction = direction,
-                IsNullable = !mandatory
+                IsNullable = !mandatory,
+                Size = size
             };
 
             if (isUserDefinedTableParameter)

--- a/EntityFrameworkExtras/StoredProcedureParserHelper.cs
+++ b/EntityFrameworkExtras/StoredProcedureParserHelper.cs
@@ -9,7 +9,14 @@ namespace EntityFrameworkExtras
     {
         public string GetParameterName(PropertyInfo propertyInfo)
         {
-            return propertyInfo.Name;
+            var rValue = propertyInfo.Name;
+
+            // grab the name of the parameter from the attribute, if it's defined.
+            var attribute = Attributes.GetAttribute<StoredProcedureParameterAttribute>(propertyInfo);
+            if (attribute != null && !string.IsNullOrEmpty(attribute.ParameterName))
+                rValue = attribute.ParameterName;
+
+            return rValue;
         }
 
         public string GetUserDefinedTableType(PropertyInfo propertyInfo)


### PR DESCRIPTION
-- Allow SqlParameter.Size to be set by providing it on the StoreProcedureParameterAttribute
-- Allow SqlParameter.ParameterName to be set to something other than the class property name by providing it on the StoreProcedureParameterAttribute
